### PR TITLE
Added logic to min_timestamp function for time delta's larger than 1 day

### DIFF
--- a/esat/utils.py
+++ b/esat/utils.py
@@ -43,7 +43,9 @@ def min_timestep(data: pd.DataFrame):
         Minimum timestep.
     """
     time_delta = data.index[1: -1] - data.index[0:-2]
-    if time_delta.min().seconds < 60:
+    if time_delta.min().days >= 1:
+        resample = f"{int(time_delta.min().days)}D"
+    elif time_delta.min().seconds < 60:
         resample = f"{time_delta.min().seconds}s"
     elif time_delta.min().seconds < 60 * 60:
         resample = f"{int(time_delta.min().seconds / 60)}min"


### PR DESCRIPTION
To fix the ZeroDivisionError that arises in data_df.resample(min_timestep(data_df)).mean() when the minimum time delta between dates is greater than a day, I added a new "if" statement to the logic in the function min_timestep to handle the case where time_delta.min() is greater than 1 day. In these cases, resample is set to time_delta.min().days, and not resampled to 1 day, unless the minimum number of days is 1.

Fixes Issue #30